### PR TITLE
method changes

### DIFF
--- a/src/SpanInterface.php
+++ b/src/SpanInterface.php
@@ -30,6 +30,13 @@ interface SpanInterface
     public function setAttributes(iterable $attributes): SpanInterface;
 
     /**
+     * Starts the current span.
+     *
+     * @return $this
+     */
+    public function start(): SpanInterface;
+
+    /**
      * Sets the current span as the "current" span.
      * This MUST start the span if not already started.
      *
@@ -44,9 +51,7 @@ interface SpanInterface
     public function finish(): void;
 
     /**
-     * Returns the traceparent identifier (for distributed tracing).
-     * If the implementor does not want to support distributed tracing, this method
-     * MUST always return null.
+     * Returns distributed tracing headers, to allow trace correlation across service boundaries.
      */
-    public function toTraceparent(): ?string;
+    public function toTraceContextHeaders(): array;
 }


### PR DESCRIPTION
- added SpanInterface::start() method
- renamed SpanInterface::toTraceParent to SpanInterface::toTraceContextHeaders. It should be an array, there can be multiple values, and not all implementations use the same header name(s).